### PR TITLE
Insert default validators as a method

### DIFF
--- a/bigdbm/process/base.py
+++ b/bigdbm/process/base.py
@@ -33,9 +33,6 @@ class BaseProcessor(ABC):
         self.client = bigdbm_client
         self.validators: list[BaseValidator] = []
 
-        # Start with global default validators
-        self.validators.extend(DEFAULT_VALIDATORS)
-
     def clear_validators(self) -> Self:
         """Remove all validators from the processor."""
         self.validators = []
@@ -47,6 +44,13 @@ class BaseProcessor(ABC):
             raise TypeError("You must pass in a valid BaseValidator instance.")
 
         self.validators.append(validator)
+        return self
+
+    def insert_default_validators(self) -> Self:
+        """Insert the default validators into the processor."""
+        for validator in DEFAULT_VALIDATORS:
+            self.add_validator(validator)
+
         return self
 
     @abstractmethod

--- a/bigdbm/process/base.py
+++ b/bigdbm/process/base.py
@@ -46,7 +46,7 @@ class BaseProcessor(ABC):
         self.validators.append(validator)
         return self
 
-    def insert_default_validators(self) -> Self:
+    def add_default_validators(self) -> Self:
         """Insert the default validators into the processor."""
         for validator in DEFAULT_VALIDATORS:
             self.add_validator(validator)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,6 +1,7 @@
 """Basic processing test. Make sure things work."""
 from bigdbm.process import SimpleProcessor, FillProcessor
 from bigdbm.schemas import MD5WithPII, IABJob
+from bigdbm.validate.simple import ZipCodeValidator
 
 
 def test_simple_processor(bigdbm_client):
@@ -28,6 +29,7 @@ def test_fill_processor(bigdbm_client):
 
     processor = FillProcessor(bigdbm_client)
     processor.add_default_validators()
-    processor.insert_
+    processor.add_validator(ZipCodeValidator(["22101"]))
+
     result: list[MD5WithPII] = FillProcessor(bigdbm_client).process(job)
     assert result

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -12,8 +12,9 @@ def test_simple_processor(bigdbm_client):
         n_hems=3
     )
 
-    result: list[MD5WithPII] = SimpleProcessor(bigdbm_client).process(job)
-    assert result
+    processor = SimpleProcessor(bigdbm_client)
+    processor.add_default_validators()
+    assert processor.process(job)
 
 
 def test_fill_processor(bigdbm_client):
@@ -25,5 +26,8 @@ def test_fill_processor(bigdbm_client):
         n_hems=3
     )
 
+    processor = FillProcessor(bigdbm_client)
+    processor.add_default_validators()
+    processor.insert_
     result: list[MD5WithPII] = FillProcessor(bigdbm_client).process(job)
     assert result


### PR DESCRIPTION
Allows finer control over the validation order. 

## Why Order Matters

Say `ContactableValidator` is being used along with `EmailValidator`. If contactable runs first, and then email validator removes emails such that a user is no longer contactable, contactable validator has semantically failed. EmailValidator should run first. But if the default validators are automatically injected into the processor object on instantiation, there's no control over which validator runs first. 