### PR TITLE
Make IABJob parameters optional

### DIFF
--- a/bigdbm/schemas.py
+++ b/bigdbm/schemas.py
@@ -1,5 +1,5 @@
 """Datatypes for working with the API."""
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from typing import Any, Self
 from enum import Enum
@@ -15,11 +15,33 @@ class ConfigDates(BaseModel):
 
 class IABJob(BaseModel):
     """Payload for creating an IAB job."""
-    intent_categories: list[str]
-    zips: list[str]
-    keywords: list[str]
-    domains: list[str]
+    intent_categories: list[str] = Field(
+        default_factory=list, alias="IABs", description="List of IAB intent categories"
+    )
+    zips: list[str] = Field(
+        default_factory=list, alias="Zips", description="List of zip codes"
+    )
+    keywords: list[str] = Field(
+        default_factory=list, alias="Keywords", description="List of keywords"
+    )
+    domains: list[str] = Field(
+        default_factory=list, alias="Domains", description="List of domains"
+    )
     n_hems: int
+
+    @model_validator(mode="after")
+    def validate_job(self) -> Self:
+        """Make sure the job has enough information to run."""
+        if all(
+            [
+                not self.intent_categories,
+                not self.keywords,
+                not self.domains
+            ]
+        ):
+            raise ValueError(
+                "Need at least one of intent categories, keywords, or domains."
+            )
 
     def as_payload(self) -> dict[str, str]:
         """Convert into dictionary payload."""

--- a/bigdbm/schemas.py
+++ b/bigdbm/schemas.py
@@ -16,16 +16,16 @@ class ConfigDates(BaseModel):
 class IABJob(BaseModel):
     """Payload for creating an IAB job."""
     intent_categories: list[str] = Field(
-        default_factory=list, alias="IABs", description="List of IAB intent categories"
+        default_factory=list, description="List of IAB intent categories"
     )
     zips: list[str] = Field(
-        default_factory=list, alias="Zips", description="List of zip codes"
+        default_factory=list, description="List of zip codes"
     )
     keywords: list[str] = Field(
-        default_factory=list, alias="Keywords", description="List of keywords"
+        default_factory=list, description="List of keywords"
     )
     domains: list[str] = Field(
-        default_factory=list, alias="Domains", description="List of domains"
+        default_factory=list, description="List of domains"
     )
     n_hems: int
 
@@ -40,8 +40,10 @@ class IABJob(BaseModel):
             ]
         ):
             raise ValueError(
-                "Need at least one of intent categories, keywords, or domains."
+                "Need at least one of intent categories, keywords, or domains.\n" + str(self.model_dump())
             )
+
+        return self
 
     def as_payload(self) -> dict[str, str]:
         """Convert into dictionary payload."""


### PR DESCRIPTION
That way, jobs can be created without needing to explicitly pass in a bunch of empty lists. 