### PR TITLE
Validation for number of sentences

### DIFF
--- a/bigdbm/validate/simple.py
+++ b/bigdbm/validate/simple.py
@@ -43,3 +43,17 @@ class MD5Validator(BaseValidator):
         return [
             md5 for md5 in md5s if md5.md5 not in self.md5_strings
         ]
+
+
+class NumSentencesValidator(BaseValidator):
+    """Ensure MD5s have at least a certain number of sentences."""
+    
+    def __init__(self, min_sentences: int) -> None:
+        """Initialize with a minimum number of sentences."""
+        self.min_sentences: int = min_sentences
+
+    def validate(self, md5s: list[MD5WithPII]) -> list[MD5WithPII]:
+        """Remove hems with fewer than the minimum number of sentences."""
+        return [
+            md5 for md5 in md5s if len(md5.pii.sentences) >= self.min_sentences
+        ]

--- a/bigdbm/validate/simple.py
+++ b/bigdbm/validate/simple.py
@@ -55,5 +55,5 @@ class NumSentencesValidator(BaseValidator):
     def validate(self, md5s: list[MD5WithPII]) -> list[MD5WithPII]:
         """Remove hems with fewer than the minimum number of sentences."""
         return [
-            md5 for md5 in md5s if len(md5.pii.sentences) >= self.min_sentences
+            md5 for md5 in md5s if len(md5.sentences) >= self.min_sentences
         ]

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -14,9 +14,6 @@ def test_simple_processor(bigdbm_client):
     )
 
     processor = SimpleProcessor(bigdbm_client)
-    processor.add_validator(ZipCodeValidator(["22101"]))
-    processor.add_validator(NumSentencesValidator(2))
-    processor.add_default_validators()
     assert processor.process(job)
 
 
@@ -29,7 +26,7 @@ def test_fill_processor(bigdbm_client):
         n_hems=3
     )
 
-    processor = FillProcessor(bigdbm_client)
+    processor = FillProcessor(bigdbm_client, intent_multiplier=5)
     processor.add_validator(ZipCodeValidator(["22101"]))
     processor.add_validator(NumSentencesValidator(2))
     processor.add_default_validators()

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,7 +1,7 @@
 """Basic processing test. Make sure things work."""
 from bigdbm.process import SimpleProcessor, FillProcessor
 from bigdbm.schemas import MD5WithPII, IABJob
-from bigdbm.validate.simple import ZipCodeValidator
+from bigdbm.validate.simple import ZipCodeValidator, NumSentencesValidator
 
 
 def test_simple_processor(bigdbm_client):
@@ -14,6 +14,8 @@ def test_simple_processor(bigdbm_client):
     )
 
     processor = SimpleProcessor(bigdbm_client)
+    processor.add_validator(ZipCodeValidator(["22101"]))
+    processor.add_validator(NumSentencesValidator(2))
     processor.add_default_validators()
     assert processor.process(job)
 
@@ -28,8 +30,9 @@ def test_fill_processor(bigdbm_client):
     )
 
     processor = FillProcessor(bigdbm_client)
-    processor.add_default_validators()
     processor.add_validator(ZipCodeValidator(["22101"]))
+    processor.add_validator(NumSentencesValidator(2))
+    processor.add_default_validators()
 
     result: list[MD5WithPII] = FillProcessor(bigdbm_client).process(job)
     assert result


### PR DESCRIPTION
# Validate Number of Sentences

- [x] Create the validator
- [x] Integrate the validator into test
- [ ] Run a sample job with the validator

## Overview

Each MD5 comes back with a sentence--the event that triggered its creation. When 'uniquifying' these `MD5` objects into `UniqueMD5`, we retain the sentence information. 

By removing leads that have fewer than `n` sentences, we ensure that a lead has a higher 'intensity'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a new validator, `NumSentencesValidator`, which ensures that MD5 entries contain a specified minimum number of sentences.
  - Enhanced validation logic within processors to include sentence count checks alongside existing validations.

- **Bug Fixes**
  - Improved validation coverage for input processing, ensuring more comprehensive checks during tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->