### PR TITLE
Allow validators to fallback on sparsity

### DIFF
--- a/bigdbm/process/base.py
+++ b/bigdbm/process/base.py
@@ -34,6 +34,11 @@ class BaseProcessor(ABC):
         self.required_validators: list[BaseValidator] = []
         self.fallback_validators: list[BaseValidator] = []
 
+    @property
+    def validators(self) -> list[BaseValidator]:
+        """Return all validators."""
+        return self.required_validators + self.fallback_validators
+
     def clear_validators(self) -> Self:
         """Remove all validators from the processor."""
         self.required_validators = []

--- a/bigdbm/process/base.py
+++ b/bigdbm/process/base.py
@@ -31,25 +31,46 @@ class BaseProcessor(ABC):
     def __init__(self, bigdbm_client: BigDBMClient) -> None:
         """Initialize with a client."""
         self.client = bigdbm_client
-        self.validators: list[BaseValidator] = []
+        self.required_validators: list[BaseValidator] = []
+        self.fallback_validators: list[BaseValidator] = []
 
     def clear_validators(self) -> Self:
         """Remove all validators from the processor."""
-        self.validators = []
+        self.required_validators = []
+        self.fallback_validators = []
         return self
 
-    def add_validator(self, validator: BaseValidator) -> Self:
-        """Add a validator instance to the processor's validators."""
+    def add_validator(self, validator: BaseValidator, allow_fallback: bool = False) -> Self:
+        """
+        Add a validator instance to the processor's validators.
+
+        Args:
+            validator: A BaseValidator instance.
+            allow_fallback: If True, the validator will be removed from validation if
+                not enough leads are found post-validation. Note that the Processor
+                must implement this behavior.
+        """
         if not isinstance(validator, BaseValidator):
             raise TypeError("You must pass in a valid BaseValidator instance.")
 
-        self.validators.append(validator)
+        if allow_fallback:
+            self.fallback_validators.append(validator)
+        else:
+            self.required_validators.append(validator)
+
         return self
 
-    def add_default_validators(self) -> Self:
-        """Insert the default validators into the processor."""
+    def add_default_validators(self, allow_fallback: bool = False) -> Self:
+        """
+        Insert the default validators into the processor.
+
+        Args:
+            allow_fallback: If True, the default validators will be removed from 
+                validation if not enough leads are found post-validation. Note that the 
+                Processor must implement this behavior.
+        """
         for validator in DEFAULT_VALIDATORS:
-            self.add_validator(validator)
+            self.add_validator(validator, allow_fallback=allow_fallback)
 
         return self
 

--- a/bigdbm/process/fill.py
+++ b/bigdbm/process/fill.py
@@ -23,6 +23,40 @@ class FillProcessor(BaseProcessor):
         super().__init__(bigdbm_client)
         self.intent_multiplier: float = intent_multiplier
 
+    def _pull_and_validate(
+        self,
+        intent_events: list[IntentEvent], 
+        n_hems: int, 
+        validators: list[BaseValidator]
+    ) -> list[MD5WithPII]:
+        """
+        Pulls and validates the leads from the intent events.
+        """
+        # Setup for iterative data pulling
+        md5s_bank: list[UniqueMD5] = self.client.uniquify_md5s(intent_events)
+        return_md5s: list[MD5WithPII] = []
+
+        while len(return_md5s) < n_hems:  # Constantly pull PII until the threshold is hit
+            if not md5s_bank:
+                break
+
+            n_delta: int = n_hems - len(return_md5s)
+            md5s_job: list[UniqueMD5] = md5s_bank[:n_delta]
+            md5s_with_pii: list[MD5WithPII] = self.client.pii_for_unique_md5s(md5s_job)
+
+            # Utilize parameterized validators to filter leads
+            validator: BaseValidator
+            for validator in validators:
+                md5s_with_pii = validator.validate(md5s_with_pii)
+
+            # Add post-validated (remaining) leads
+            return_md5s.extend(md5s_with_pii)
+
+            # Update tracking
+            del md5s_bank[:n_delta]
+
+        return return_md5s
+
     def process(self, iab_job: IABJob) -> list[MD5WithPII]:
         """
         1. Pull 2x as much intent data as requested. (adjustable on instantiation)
@@ -40,30 +74,20 @@ class FillProcessor(BaseProcessor):
         # Run the first job for MD5s
         list_queue_id: int = self.client.create_and_wait(iab_job)
         intent_events: list[IntentEvent] = self.client.retrieve_md5s(list_queue_id)
-        md5s_bank: list[UniqueMD5] = self.client.uniquify_md5s(intent_events)
 
-        # Setup for iterative data pulling
-        return_md5s: list[MD5WithPII] = []
+        # Run with all validators first
+        return_md5s: list[MD5WithPII] = self._pull_and_validate(intent_events, n_hems, self.validators)
 
-        # Constantly pull PII until the threshold is hit
-        while len(return_md5s) < n_hems:
-            if not md5s_bank:
-                break
+        # If we have enough leads, return them
+        if len(return_md5s) >= n_hems:
+            return return_md5s
 
-            n_delta: int = n_hems - len(return_md5s)
-            md5s_job: list[UniqueMD5] = md5s_bank[:n_delta]
-            md5s_with_pii: list[MD5WithPII] = self.client.pii_for_unique_md5s(md5s_job)
-
-            # Utilize all registered validators to filter leads
-            validator: BaseValidator
-            for validator in self.validators:
-                md5s_with_pii = validator.validate(md5s_with_pii)
-
-            # Add post-validated (remaining) leads
-            return_md5s.extend(md5s_with_pii)
-
-            # Update tracking
-            del md5s_bank[:n_delta]
+        # If we don't have enough leads, try again with fallen back validators
+        existing_md5s: list[str] = [i.md5 for i in return_md5s]
+        return_md5s += self._pull_and_validate(
+            [i for i in intent_events if i.md5 not in existing_md5s],  # only run on events not used
+            n_hems - len(return_md5s),  # only the remaining leads needed
+            self.required_validators  # only required, no fallback validators
+        )
 
         return return_md5s
-    

--- a/bigdbm/process/fill.py
+++ b/bigdbm/process/fill.py
@@ -97,3 +97,71 @@ class FillProcessor(BaseProcessor):
         )
 
         return return_md5s
+
+
+# ---- Deprecation Zone ----
+
+class NoFallbackFillProcessor(BaseProcessor):
+    """
+    Deprecated `FillProcessor` that does not retry without fallback validators.
+    
+    Processor that pulls 2x as much intent data to start, and then keeps trying more
+    to fill the PII.
+
+    1. Pull 2x as much intent data as requested. (adjustable on instantiation)
+    2. Request 1x as much PII.
+    3. Keep requesting PII on more data until filled.
+
+    Can return less than the requested amount of data if:
+    - The PII hit rate is less than 0.5x, as 2x data is not enough.
+    - There is not enough intent data returned.
+    """
+
+    def __init__(self, bigdbm_client: BigDBMClient, intent_multiplier: float = 2.5) -> None:
+        super().__init__(bigdbm_client)
+        self.intent_multiplier: float = intent_multiplier
+
+    def process(self, iab_job: IABJob) -> list[MD5WithPII]:
+        """
+        1. Pull 2x as much intent data as requested. (adjustable on instantiation)
+        2. Request 1x as much PII.
+        3. Keep requesting PII on more data until filled.
+
+        Can return less than the requested amount of data if:
+        - The PII hit rate is less than 0.5x, as 2x data is not enough.
+        - There is not enough intent data returned.
+        """
+        # Extend the number of hems in the initial job
+        n_hems: int = iab_job.n_hems  # true amount of PII to return
+        iab_job.n_hems = int(iab_job.n_hems * self.intent_multiplier)
+
+        # Run the first job for MD5s
+        list_queue_id: int = self.client.create_and_wait(iab_job)
+        intent_events: list[IntentEvent] = self.client.retrieve_md5s(list_queue_id)
+        md5s_bank: list[UniqueMD5] = self.client.uniquify_md5s(intent_events)
+
+        # Setup for iterative data pulling
+        return_md5s: list[MD5WithPII] = []
+
+        # Constantly pull PII until the threshold is hit
+        while len(return_md5s) < n_hems:
+            if not md5s_bank:
+                break
+
+            n_delta: int = n_hems - len(return_md5s)
+            md5s_job: list[UniqueMD5] = md5s_bank[:n_delta]
+            md5s_with_pii: list[MD5WithPII] = self.client.pii_for_unique_md5s(md5s_job)
+
+            # Utilize all registered validators to filter leads
+            validator: BaseValidator
+            for validator in self.validators:
+                md5s_with_pii = validator.validate(md5s_with_pii)
+
+            # Add post-validated (remaining) leads
+            return_md5s.extend(md5s_with_pii)
+
+            # Update tracking
+            del md5s_bank[:n_delta]
+
+        return return_md5s
+    

--- a/bigdbm/process/fill.py
+++ b/bigdbm/process/fill.py
@@ -17,6 +17,9 @@ class FillProcessor(BaseProcessor):
     Can return less than the requested amount of data if:
     - The PII hit rate is less than 0.5x, as 2x data is not enough.
     - There is not enough intent data returned.
+
+    If the initial pull does not return enough data, the processor will try again without
+    the fallback validators, retaining whatever leads were already pulled.
     """
 
     def __init__(self, bigdbm_client: BigDBMClient, intent_multiplier: float = 2.5) -> None:
@@ -66,6 +69,9 @@ class FillProcessor(BaseProcessor):
         Can return less than the requested amount of data if:
         - The PII hit rate is less than 0.5x, as 2x data is not enough.
         - There is not enough intent data returned.
+
+        If the initial pull does not return enough data, the processor will try again without
+        the fallback validators, retaining whatever leads were already pulled.
         """
         # Extend the number of hems in the initial job
         n_hems: int = iab_job.n_hems  # true amount of PII to return


### PR DESCRIPTION
# Processor and Validator Fallbacks

- [x] Implement in the validator additions
- [x] Update all pre-built validators to use correct validator naming
- [x] Update `FillProcessor` to implement fallback logic

## Overview

Fixes #21. 

In case there are less than `n_hems` leads in the `FillProcessor` output, any validators added with `allow_fallback=True` will be removed and the remaining `n_hems - len(current_hems)` will be processed with the FillProcessor logic. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a separated structure for validators, enhancing management flexibility.
	- Added a consolidated view for both required and fallback validators.

- **Improvements**
	- Refactored data retrieval logic in the `FillProcessor` for better handling of leads.
	- Improved readability and maintainability of the code.

- **Documentation**
	- Updated comments and docstrings to clarify new logic and control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->