### PR TITLE
Create a medium net worth validator

### DIFF
--- a/bigdbm/validate/pii.py
+++ b/bigdbm/validate/pii.py
@@ -82,7 +82,18 @@ class HNWValidator(BaseValidator):
 
     def validate(self, md5s: list[MD5WithPII]) -> list[MD5WithPII]:
         """Remove hems that do not match the HNW requirement."""
+        income_levels = {
+            "N. $200,000-$249,999", 
+            "O. $250K +"
+        }
+        
+        net_worth_levels = {
+            "I. $250,000 - $499,999", 
+            "J. Greater than $499,999"
+        }
+        
         return [
-            md5 for md5 in md5s if md5.pii.household_income in {"N. $200,000-$249,999", "O. $250K +"}
-            and md5.pii.household_net_worth in {"I. $250,000 - $499,999", "J. Greater than $499,999"}
+            md5 for md5 in md5s 
+            if md5.pii.household_income in income_levels 
+            and md5.pii.household_net_worth in net_worth_levels
         ]

--- a/bigdbm/validate/pii.py
+++ b/bigdbm/validate/pii.py
@@ -45,6 +45,20 @@ class AgeValidator(BaseValidator):
         return [md5 for md5 in md5s if is_valid(md5)]
 
 
+class MNWValidator(BaseValidator):
+    """
+    Only show hems of people with at least $100k in household 
+    income _and_ $100k in household net worth.
+    """
+
+    def validate(self, md5s: list[MD5WithPII]) -> list[MD5WithPII]:
+        """Remove hems that do not match the HNW requirement."""
+        return [
+            md5 for md5 in md5s if md5.pii.household_income in {"N. $200,000-$249,999", "O. $250K +"}
+            and md5.pii.household_net_worth in {"I. $250,000 - $499,999", "J. Greater than $499,999"}
+        ]
+
+
 class HNWValidator(BaseValidator):
     """
     Only show hems of people with at least $200k in household 

--- a/bigdbm/validate/pii.py
+++ b/bigdbm/validate/pii.py
@@ -53,9 +53,24 @@ class MNWValidator(BaseValidator):
 
     def validate(self, md5s: list[MD5WithPII]) -> list[MD5WithPII]:
         """Remove hems that do not match the HNW requirement."""
+        income_levels = {
+            "K. $100,000-$149,999", 
+            "L. $150,000-$174,999", 
+            "M. $175,000-$199,999", 
+            "N. $200,000-$249,999", 
+            "O. $250K +"
+        }
+        
+        net_worth_levels = {
+            "H. $100,000 - $249,999", 
+            "I. $250,000 - $499,999", 
+            "J. Greater than $499,999"
+        }
+        
         return [
-            md5 for md5 in md5s if md5.pii.household_income in {"N. $200,000-$249,999", "O. $250K +"}
-            and md5.pii.household_net_worth in {"I. $250,000 - $499,999", "J. Greater than $499,999"}
+            md5 for md5 in md5s 
+            if md5.pii.household_income in income_levels 
+            and md5.pii.household_net_worth in net_worth_levels
         ]
 
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,7 +1,8 @@
 """Basic processing test. Make sure things work."""
 from bigdbm.process import SimpleProcessor, FillProcessor
 from bigdbm.schemas import MD5WithPII, IABJob
-from bigdbm.validate.simple import ZipCodeValidator, NumSentencesValidator
+from bigdbm.validate.simple import ZipCodeValidator
+from bigdbm.validate.pii import HNWValidator, MNWValidator
 
 
 def test_simple_processor(bigdbm_client):
@@ -29,6 +30,23 @@ def test_fill_processor(bigdbm_client):
     processor = FillProcessor(bigdbm_client)
     processor.add_validator(ZipCodeValidator(["22101"]))
     processor.add_default_validators()
+
+    result: list[MD5WithPII] = FillProcessor(bigdbm_client).process(job)
+    assert result
+
+
+def test_hnw_mnw(bigdbm_client):
+    job = IABJob(
+        intent_categories=["Real Estate>Real Estate Buying and Selling"],
+        domains=[],
+        keywords=[],
+        zips=["22101"],
+        n_hems=3
+    )
+
+    processor = FillProcessor(bigdbm_client)
+    processor.add_validator(HNWValidator(), allow_fallback=True)
+    processor.add_validator(MNWValidator())
 
     result: list[MD5WithPII] = FillProcessor(bigdbm_client).process(job)
     assert result


### PR DESCRIPTION
# Medium Net Worth Validation

- [x] Find and catalog all the available designations 
- [x] Write the `MNWValidator`
- [x] Write a new test for the below example, using HNW with fallbacks to MNW

## Overview

Same thing as HNW but looser critera. The idea is that it can be used in conjunction with HNWValidator with fallbacks.

## Example

```python
processor.add_validator(HNWValidator(), allow_fallbacks=True)
processor.add_validator(MNWValidator())
```

This would then first try to fill up with HNWs, and if there aren't enough, will fill the empty slots with MNWs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new `MNWValidator` class to filter individuals based on financial criteria, ensuring a household income and net worth of at least $100,000.
	- Added a new test function to validate the integration of the `HNWValidator` and `MNWValidator` in the processing logic.

- **Improvements**
	- Updated the existing `HNWValidator` class to align with the new validation criteria, enhancing consistency and maintainability.
	- Enhanced the testing framework by integrating more robust validation mechanisms, improving data processing accuracy and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->