### PR TITLE
Retry API-dependent validations

### DIFF
--- a/bigdbm/validate/email.py
+++ b/bigdbm/validate/email.py
@@ -2,6 +2,8 @@
 import requests
 
 from concurrent.futures import ThreadPoolExecutor
+import time
+import random
 
 from bigdbm.schemas import MD5WithPII
 from bigdbm.validate.base import BaseValidator
@@ -36,6 +38,16 @@ class EmailValidator(BaseValidator):
 
         return response_json["resultcode"] == 1
 
+    def _validate_with_retry(self, email: str) -> bool:
+        """Retry the validation if it fails."""
+        for _ in range(3):
+            try:
+                return self._validate_email(email)
+            except requests.RequestException as e:
+                time.sleep(random.uniform(3, 5))
+
+        raise e
+
     def validate(self, md5s: list[MD5WithPII]) -> list[MD5WithPII]:
         """Remove any emails that are not 'good'."""
         # Extract all the emails
@@ -46,7 +58,7 @@ class EmailValidator(BaseValidator):
         # Validate all the emails
         with ThreadPoolExecutor(max_workers=self.max_threads) as executor:
             valid_emails_idx: list[bool] = list(
-                executor.map(self._validate_email, all_emails)
+                executor.map(self._validate_with_retry, all_emails)
             )
 
         # Extract valid emails

--- a/bigdbm/validate/email.py
+++ b/bigdbm/validate/email.py
@@ -46,7 +46,7 @@ class EmailValidator(BaseValidator):
             except requests.RequestException as e:
                 time.sleep(random.uniform(3, 5))
 
-        raise e
+        raise
 
     def validate(self, md5s: list[MD5WithPII]) -> list[MD5WithPII]:
         """Remove any emails that are not 'good'."""

--- a/bigdbm/validate/phone.py
+++ b/bigdbm/validate/phone.py
@@ -56,7 +56,7 @@ class PhoneValidator(BaseValidator):
             except requests.RequestException as e:
                 time.sleep(random.uniform(3, 5))
 
-        raise e
+        raise
 
     def validate(self, md5s: list[MD5WithPII]) -> list[MD5WithPII]:
         """Remove any phone numbers that are not 'good'."""


### PR DESCRIPTION
Fixes #29. 

Saw a 524 error on email validation crashing the system.

- [x] Retry email validation on error
- [x] Retry phone validation on error

Max of 3 attempts. Random delays in a uniform distribution between 3 and 5 seconds to prevent retry spams (given multithreading, if there's a rate limit or something and all concurrent jobs fail).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a retry mechanism for email validation, improving resilience against transient network issues.
	- Implemented a retry mechanism for phone number validation, enhancing reliability during validation attempts.

- **Bug Fixes**
	- Improved error handling for email and phone validation to manage temporary failures more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->