### PR TITLE
Proper schema for same person detection

### DIFF
--- a/bigdbm/validate/simple.py
+++ b/bigdbm/validate/simple.py
@@ -66,7 +66,7 @@ class SamePersonValidator(BaseValidator):
                 
             unique_leads[lead.hash()] = lead
         
-        return unique_leads
+        return list(unique_leads.values())
 
 
 class NumSentencesValidator(BaseValidator):


### PR DESCRIPTION
`SamePersonValidator.validate` should be returning a `list[MD5WithPII]` not a `dict[str, MD5WithPII]` as is used within the detection algorithm. 