### PR TITLE
AI insights on leads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ __pycache__/
 keys.yaml
 
 Test.ipynb
+
+# Dev things
+result.pkl

--- a/bigdbm/analyze/__init__.py
+++ b/bigdbm/analyze/__init__.py
@@ -1,2 +1,2 @@
 """Generate string insights based on lead data."""
-from bigdbm.analyze.insights import OpenAIInsightGenerator
+from bigdbm.analyze.insights import OpenAIInsightsGenerator

--- a/bigdbm/analyze/__init__.py
+++ b/bigdbm/analyze/__init__.py
@@ -1,1 +1,2 @@
 """Generate string insights based on lead data."""
+from bigdbm.analyze.insights import OpenAIInsightGenerator

--- a/bigdbm/analyze/__init__.py
+++ b/bigdbm/analyze/__init__.py
@@ -1,0 +1,1 @@
+"""Generate string insights based on lead data."""

--- a/bigdbm/analyze/base.py
+++ b/bigdbm/analyze/base.py
@@ -1,0 +1,19 @@
+"""Defines the base analyzer."""
+from abc import ABC, abstractmethod
+
+from bigdbm.schemas import MD5WithPII
+
+
+class BaseAnalyzer(ABC):
+    """Base class for analyzers."""
+
+    @abstractmethod
+    def analyze(self, pii_md5s: list[MD5WithPII]) -> str:
+        """
+        Take a list of MD5s with PII and perform analysis according to the purpose
+        of the analyzer.
+
+        Returns:
+            str: The result of the analysis as a string.
+        """
+        

--- a/bigdbm/analyze/insights/__init__.py
+++ b/bigdbm/analyze/insights/__init__.py
@@ -81,4 +81,9 @@ class OpenAIInsightGenerator(BaseAnalyzer):
         if not lead_insights:
             return "No insights on these leads at the moment."
 
+        # Add markdown bullet points to each insight if not already present
+        for i, insight in enumerate(lead_insights.insights):
+            if not insight.startswith("- "):
+                lead_insights.insights[i] = "- " + insight
+
         return "\n".join(lead_insights.insights)

--- a/bigdbm/analyze/insights/__init__.py
+++ b/bigdbm/analyze/insights/__init__.py
@@ -1,0 +1,84 @@
+"""Use an LLM to generate insights from PII data."""
+from pydantic import BaseModel, Field
+
+from bigdbm.analyze.base import BaseAnalyzer
+from bigdbm.schemas import MD5WithPII
+
+from bigdbm.analyze.insights.prompt import SYSTEM_PROMPT
+from bigdbm.format.csv import CSVStringFormatter
+
+
+class LeadInsights(BaseModel):
+    """Insights generated from lead data."""
+    thoughts: str = Field(
+        ...,
+        description=(
+            "String of any thinking that'll help you work through the leads, any "
+            "patterns, and arrive at your insights. Think of this as a scratchpad you "
+            "can use to note down things you notice to be thorough and refined in your "
+            "final insights, and to calculate real numbers (percentages etc.)."
+        )
+    )
+    insights: list[str] = Field(
+        ...,
+        description=(
+            "List of strings where each string is a detailed insight derived from "
+            "the lead data. These insights focus on IAB intent categories and personal "
+            "information of each lead. They provide actionable information to help "
+            "understand how to sell to these leads effectively. Insights combine "
+            "multiple attributes (e.g., marital status, net worth, and intent "
+            "categories) to make informed assumptions about what the leads would want. "
+            "The language used is tailored for the person who will be using these "
+            "leads, providing critical and analytical observations that can guide "
+            "marketing strategies and personalized outreach efforts."
+        )
+    )
+
+
+class OpenAIInsightGenerator(BaseAnalyzer):
+    """Generates insights from PII data using OpenAI."""
+
+    def __init__(self, openai_api_key: str):
+        try:
+            from openai import OpenAI
+        except ImportError:
+            raise ImportError("Please install the openai package to use this analyzer.")
+        
+        self.openai_client = OpenAI(api_key=openai_api_key)
+
+    def analyze(self, pii_md5s: list[MD5WithPII]) -> str:
+        """
+        Analyze the list of MD5s with PII and generate insights using an LLM.
+
+        Args:
+            pii_md5s (list[MD5WithPII]): List of MD5 hashes with associated PII data.
+
+        Returns:
+            str: Generated insights as a string.
+        """
+        result = self.openai_client.beta.chat.completions.parse(
+            model="gpt-4o",
+            messages=[
+                {
+                    "role": "system",
+                    "content": SYSTEM_PROMPT
+                },
+                {
+                    "role": "user",
+                    "content": CSVStringFormatter().format_md5s(pii_md5s)
+                }
+            ],
+            max_tokens=4095,
+            temperature=1,
+            top_p=1,
+            frequency_penalty=0,
+            presence_penalty=0,
+            response_format=LeadInsights
+        )
+
+        lead_insights: LeadInsights | None = result.choices[0].message.parsed
+
+        if not lead_insights:
+            return "No insights on these leads at the moment."
+
+        return "\n".join(lead_insights.insights)

--- a/bigdbm/analyze/insights/__init__.py
+++ b/bigdbm/analyze/insights/__init__.py
@@ -35,7 +35,7 @@ class LeadInsights(BaseModel):
     )
 
 
-class OpenAIInsightGenerator(BaseAnalyzer):
+class OpenAIInsightsGenerator(BaseAnalyzer):
     """Generates insights from PII data using OpenAI."""
 
     def __init__(self, openai_api_key: str):

--- a/bigdbm/analyze/insights/__init__.py
+++ b/bigdbm/analyze/insights/__init__.py
@@ -42,7 +42,7 @@ class OpenAIInsightGenerator(BaseAnalyzer):
         try:
             from openai import OpenAI
         except ImportError:
-            raise ImportError("Please install the openai package to use this analyzer.")
+            raise ImportError("Please install this package with the 'openai' extra.")
         
         self.openai_client = OpenAI(api_key=openai_api_key)
 

--- a/bigdbm/analyze/insights/__init__.py
+++ b/bigdbm/analyze/insights/__init__.py
@@ -57,7 +57,7 @@ class OpenAIInsightGenerator(BaseAnalyzer):
             str: Generated insights as a string.
         """
         result = self.openai_client.beta.chat.completions.parse(
-            model="gpt-4o",
+            model="gpt-4o-2024-08-06",
             messages=[
                 {
                     "role": "system",

--- a/bigdbm/analyze/insights/prompt.py
+++ b/bigdbm/analyze/insights/prompt.py
@@ -1,0 +1,69 @@
+"""Prompt `SYSTEM_PROMPT` for the insight generator."""
+
+SYSTEM_PROMPT = r"""You are a lead generation expert. You take a CSV string of a list of leads with all necessary metadata and come up with useful insights based on the specific set of leads. 
+
+The leads are intent based, meaning they're aggregated based on IAB intent categories (each category is a column in the CSV). Your insights should center around these IAB categories, using the personal information of each lead (age, demographics, income, gender, etc.) to create insights and narratives that will help to understand how to sell to these leads. 
+
+You always respond in JSON with the following schema:
+
+{
+    "thoughts": "String of any thinking that'll help you work through the leads, any patterns, and arrive at your insights. Think of this as a scratchpad you can use to note down things you notice to be thorough and refined in your final insights, and to calculate real numbers (percentages etc.).",
+    "insights": ["list of strings where each string is an insight"]
+}
+
+Both fields are required at all times. 
+
+For example, given these leads:
+
+Pre-Movers,Residential,Sellers,Brokers And Agents,Mortgages,First-Time Home Buyer,first_name,last_name,email_1,email_2,email_3,phone_1,phone_1_dnc,phone_2,phone_2_dnc,phone_3,phone_3_dnc,address,city,state,zip_code,gender,age,n_household_children,credit_range,home_owner_status,household_income,marital_status,household_net_worth,occupation,n_household_veterans,md5
+x,x,x,x,x,,Kasbaum,Surbhi,bsinghal@gmail.com,vsinghal@birchstreet.net,,9493947193,True,,,,,5 Agave Ct,Ladera Ranch,CA,92694,Female,43,0,C. 700-749,Home Owner,0. Unknown,Single,A. Unknown,Professional,0,8c5622582a8602ea75561b8c0b61c441
+x,x,,x,x,,Nicholas,Mustain,nmustain717@gmail.com,nicholasmustain@gmail.com,ndawg7@hotmail.com,8587765087,False,7149164582,False,7147529113,False,76 Mercantile Way Apt 716,Ladera Ranch,CA,92694,Male,36,0,I. Unknown,Home Owner,"E. $40,000-$49,999",Single,"I. $250,000 - $499,999",,0,d7e42fa282f5d2e1520e25e4f7d3e0a9
+x,,,x,x,,Bryan,Zirkel,bjzirkel@yahoo.com,bzirkel@aol.com,,6502242165,True,,,,,11 Merrill Hl,Ladera Ranch,CA,92694,Male,44,1,C. 700-749,Home Owner,"K. $100,000-$149,999",Married,"J. Greater than $499,999",Professional,0,453200191c17da594dd0596910d1416a
+x,,,,x,x,Tammy,Salvatore,jjsalvatore@gmail.com,,,4407586958,True,8312953269,True,,,7 Wheatstone Fa Rm,Ladera Ranch,CA,92694,Female,55,1,D. 650-699,Home Owner,"N. $200,000-$249,999",Married,"J. Greater than $499,999",,0,93d8608ff9fe8ced8e66cfdca89d62b7
+,,,,x,x,Summer,Nichols,lost59@aol.com,,,9493384663,True,,,,,18 Duskywing Ct,Ladera Ranch,CA,92694,Female,47,1,B. 750-799,Home Owner,O. $250K +,Married,"J. Greater than $499,999",Homemaker,0,f2be2b2dd6e479a06355b48daa624fd2
+x,x,,x,x,,Jessica,Rogers,jrogers1543@gmail.com,,,,,,,,,12 Jarano St,Rancho Mission Viejo,CA,92694,Female,40,1,I. Unknown,Home Owner,"K. $100,000-$149,999",Unknown,"J. Greater than $499,999",,0,779af13f003126c8dbd917a902626ece
+x,x,,,x,,Bobby,Mathew,bobbymathew@outlook.com,bobbyomathew@gmail.com,,,,,,,,1176 Roots Way,Rancho Mission Viejo,CA,92694,,,,,,,,,,,ee52b10169e0f7fd1ae8fe64876ce320
+x,x,,,x,,Bobby,Mathew,bobbymathew@outlook.com,bobbyomathew@gmail.com,,,,,,,,1176 Roots Way,Rancho Mission Viejo,CA,92694,,,,,,,,,,,8058af31871cb8c6073f4b7d67afae7c
+,x,,x,x,,Nicole,Miller,,,,9496099088,True,,,,,11 Lanesboro Rd,Ladera Ranch,CA,92694,Female,48,1,C. 700-749,Home Owner,O. $250K +,Single,"J. Greater than $499,999",,0,f3049a89955537f02209ab3d4afc9382
+x,x,,x,x,,Patricia,Shelden,ksantanello@hotmail.com,,,,,,,,,66 Kyle Ct,Ladera Ranch,CA,92694,Female,65,0,I. Unknown,Unknown,"L. $150,000-$174,999",Unknown,A. Unknown,,0,6666eeb15705b2c3096b26e378954a7f
+x,,,x,x,,Victor,Celani,victorcelani@hotmail.com,,,9492357108,True,,,,,4 Volanta Ct,Rancho Mission Viejo,CA,92694,Male,63,1,I. Unknown,Home Owner,O. $250K +,Married,"J. Greater than $499,999",Professional,0,57015a69449fbe74efe452b15f0ba7ca
+x,,,x,x,,Ioana,Bozga,paulscustomcabinets@gmail.com,ramsiscafe@gmail.com,jmlarson9601@gmail.com,9496902452,True,7149280705,False,7149289010,True,26 Reston Way,Ladera Ranch,CA,92694,Female,56,0,D. 650-699,Home Owner,"F. $50,000-$59,999",Single,A. Unknown,Dentist,0,af634999c8f323431b8ca851e4a3a52a
+,x,,x,,,Michael,Bryant,mbryant82@hotmail.com,,,7143963408,False,,,,,1 Lirico Ct,Rancho Mission Viejo,CA,92694,Male,42,0,I. Unknown,Home Owner,"G. $60,000-$74,999",Single,"H. $100,000 - $249,999",,0,6cfe278176ca6f8f23dfcc02b4770d32
+,x,,x,,,Kim,MacLeod,kimmmacleod@gmail.com,kmacleod@apple.com,,4153284749,True,,,,,2000 Corporate Dr Apt 522,Ladera Ranch,CA,92694,Female,71,0,I. Unknown,Home Owner,0. Unknown,Single,A. Unknown,,0,c8fe0e2c214105383a80df21f1689a46
+x,,,x,x,,Paul,Lee,,,,6027435891,True,4802369581,True,,,7 Emmy Ln,Ladera Ranch,CA,92694,Male,53,1,B. 750-799,Home Owner,O. $250K +,Married,"J. Greater than $499,999",,0,a8252392715554c73e0ce5161daf7db1
+,x,,x,,,Glen,Lunzman,glenlunzman@gmail.com,,,7147684941,True,9494159607,False,,,15 Risa St,Rancho Mission Viejo,CA,92694,Male,69,0,I. Unknown,Home Owner,"K. $100,000-$149,999",Married,"J. Greater than $499,999",Real Estate/Realtor,0,62605a3516a1ef0d1be5b577fe5366db
+x,,,,x,,Natalie,Rulon,laurarulon5@gmail.com,natalierulon@gmail.com,,7049293310,True,,,,,720 Stirrup Rd,Rancho Mission Viejo,CA,92694,Female,26,1,B. 750-799,Home Owner,"K. $100,000-$149,999",Single,"J. Greater than $499,999",,0,e66ba73f2d713dd6cfdf3603ffbc4378
+x,x,,,x,,Lance,Justice,lancejustice@gmail.com,veronicaamontoya@gmail.com,cornbread1544@hotmail.com,6192772377,True,,,,,16 Arlington St,Ladera Ranch,CA,92694,Male,42,0,I. Unknown,Home Owner,"H. $75,000-$99,999",Unknown,A. Unknown,Self Employed,0,5a0c5aa25e2dd7093b7514a6e9075cac
+x,,,,x,,Josh,Smiley,joshdsmiley@gmail.com,hilliardsheryl@gmail.com,,7142045493,False,9495478206,True,,,61 Ventada St,Rancho Mission Viejo,CA,92694,Male,42,1,I. Unknown,Home Owner,O. $250K +,Married,"J. Greater than $499,999",,0,b678c0c7718d284317e882281f7df596
+x,,x,x,x,,Margarita,Arvizu,margaritaarvizu@gmail.com,,,,,,,,,154 Luneta Ln,Rancho Mission Viejo,CA,92694,Female,64,1,I. Unknown,Home Owner,"H. $75,000-$99,999",Single,"I. $250,000 - $499,999",Self Employed,0,f694a0b5872e51792c0ef34974d47523
+x,,,,x,,John,Madau,,,,4806486655,True,4805163639,True,,,70 Sansovino,Ladera Ranch,CA,92694,Male,56,0,I. Unknown,Home Owner,0. Unknown,Married,A. Unknown,Professional,0,fd8884fe82c128373588ef028f165d0a
+x,x,,x,x,x,Brenda,Gifford,brenda_toth@hotmail.com,,,9492466943,False,9492469439,False,,,9 Earlywood,Ladera Ranch,CA,92694,Female,45,0,I. Unknown,Renter,"L. $150,000-$174,999",Unknown,A. Unknown,,0,cbd16fc6ead3fb059c6bd0c6103bd430
+x,,,x,x,,John,Gresko,johngresko@outlook.com,,,,,,,,,1 Allbrook Ct,Ladera Ranch,CA,92694,Male,49,1,C. 700-749,Home Owner,"K. $100,000-$149,999",Married,"J. Greater than $499,999",Broker/Stock/Trader,0,bd2c769daec78a2314d67a3d4322cfda
+x,,,,x,,Pamela,Bonas,pamelabtaylor@gmail.com,,,,,,,,,7 Shepherd Ct,Ladera Ranch,CA,92694,Female,66,0,B. 750-799,Home Owner,"M. $175,000-$199,999",Married,"J. Greater than $499,999",,0,5e9c7373028ac2254283467b5a55517a
+x,,,x,x,,Jaime,Carillo,jaime.burgueno@outlook.com,,,,,,,,,8 Pickering Cir,Ladera Ranch,CA,92694,,,,,,,,,,,534c183eec7e34db1bdc6cf5faa4d85c
+x,,,x,,,Cesar,Sabroso,abuduru@hotmail.com,csabroso@gmail.com,,9548155726,False,,,,,41 Reese Crk,Ladera Ranch,CA,92694,Male,49,1,C. 700-749,Home Owner,"L. $150,000-$174,999",Single,"J. Greater than $499,999",,0,c8d5c9edadeba29a850281e37b1852da
+x,,,x,x,,Mike,Mell,mikemell@gmail.com,,,6195729836,False,9493068713,False,9493009674,True,112 Baculo St,Rancho Mission Viejo,CA,92694,Male,53,1,I. Unknown,Home Owner,"K. $100,000-$149,999",Single,"H. $100,000 - $249,999",,0,e2d96a60a9b39a8e4feeb8c57b9e1012
+,x,,x,,,Kimberly,Miyasaki,kimhsu@gmail.com,,,9492122611,True,,,,,19 Bluewing Ln,Ladera Ranch,CA,92694,Female,47,1,F. 550-599,Home Owner,O. $250K +,Married,"J. Greater than $499,999",,0,8d506ed7ae8a52dd02b5a1333dc86a3b
+,x,,x,,,Douglas,Miller,josel8995@hotmail.com,dakidjr5@gmail.com,rosadoamichael7@gmail.com,,,,,,,70 Sklar St Apt 1305,Ladera Ranch,CA,92694,,,,,,,,,,,2d373d964b0da4ce6d539a6c83fca053
+x,,,,x,,Helen,Winkler,helenhunt03@gmail.com,,,9496062008,True,,,,,7 Friar Ln,Ladera Ranch,CA,92694,Female,43,1,D. 650-699,Home Owner,"L. $150,000-$174,999",Married,"J. Greater than $499,999",,0,252f6ac42a570770cea5ca185e501080
+
+An example list of appropriate, detailed insights would be:
+
+Here are the insights without any bolding:
+
+- 56% of the leads are categorized as Pre-Movers, with 13 out of 15 also showing interest in Mortgages. This suggests a strong likelihood that these individuals are in the market for a new home and actively seeking financing options. For instance, Jessica Rogers (Age 40) and Nicholas Mustain (Age 36) are both Pre-Movers interested in Mortgages, indicating they might be actively searching for home financing solutions.
+
+- 63% of the leads have a household net worth greater than $499,999, with 10 of these 17 being Pre-Movers. This indicates a strong potential market for upscale residential properties or luxury home services. For example, Summer Nichols (Age 47) and Paul Lee (Age 53), both homeowners with net worths over $500,000, are likely interested in high-end real estate or significant home improvements.
+
+- 41% of the leads have a credit score in the range of 700-749, with most of them being homeowners. This suggests that these individuals could be prime candidates for mortgage refinancing or home equity loans. For example, Bryan Zirkel (Age 44) and John Gresko (Age 49) both fall into this credit range and are homeowners, indicating they might benefit from competitive refinancing offers.
+
+- 33% of the leads are married with a household net worth greater than $499,999, and 6 out of these 9 are Pre-Movers. This indicates they may be looking for larger or more prestigious homes to accommodate their lifestyle. For instance, Tammy Salvatore (Age 55) and Victor Celani (Age 63) are both married, high-net-worth Pre-Movers, suggesting they might be interested in luxury properties or exclusive neighborhoods.
+
+- Among the female leads, 30% are single homeowners with a household income exceeding $150,000. These individuals may be interested in financial planning services, home improvement, or investment opportunities. For example, Nicole Miller (Age 48) and Margarita Arvizu (Age 64) both fit this profile, indicating they could be targeted for personalized financial advice or investment in real estate.
+
+---
+
+Obviously, the above example insights are specific to a list of real estate-related leads. If the leads have different intent IAB categories, think from the perspective of the person who would be receiving those leads when working through your insights.
+Write your insights with language as if you're speaking to the person who is going to be using these leads.
+Finally, when constructing your insights and deciding what to look for, try to combine attributes and be super critical and analytical, ex. looking at the combination of both marital status and net worth and intent categories to make an assumption about what those leads would want.
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,4 @@ Repository = "https://github.com/Standard-Labs/bigdbm-python.git"
 
 [project.optional-dependencies]
 logfire = ["logfire"]
+openai = ["openai==1.41.1"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-pydantic
+pydantic>=2.8.2
 pandas
 requests
-logfire
+logfire>=0.50.1
+openai==1.41.1
 
 python-dotenv


### PR DESCRIPTION
Generate AI insights on a `list[MD5WithPII]`. Utilize OpenAI's new structured `json_schema` mode on the latest GPT-4o snapshot.

Creates an `analyze` structure used outside of the main processing pipeline. `BaseAnalyzer.analyze` method takes a list of PII leads and returns a string. 

`OpenAIInsightsGenerator` is implemented. 

```python
result: list[MD5WithPII] = processor.process(...)

from bigdbm.analyze import OpenAIInsightsGenerator

insights: str = OpenAIInsightsGenerator(openai_api_key=...).analyze(result)
```

Note that there's no in-built logging here as this generator doesn't requrie the BigDBM client. This is the same problem as with the formatters (to be known as deliverers) and validators. Log externally, i.e. from the user code.