### PR TITLE
Include intent info in Follow Up Boss

### DIFF
--- a/bigdbm/deliver/followupboss/vanilla.py
+++ b/bigdbm/deliver/followupboss/vanilla.py
@@ -131,9 +131,22 @@ class FollowUpBossDeliverer(BaseOutputDeliverer):
         if md5_with_pii.pii.mobile_phones:
             person_data["phones"] = [{"value": phone.phone} for phone in md5_with_pii.pii.mobile_phones]
 
+        # Prepare sentences
+        sentences: list[str] = []
+        for sentence in md5_with_pii.sentences:
+            if ">" in sentence:
+                sentences.append(sentence.split(">")[-1])
+                continue
+            
+            sentences.append(sentence)
+        
+        sentences_str = ", ".join(sentences)
+        sentences_str = f"Intents: {sentences_str}."
+
         return {
             "source": self.system,
             "system": self.system,
+            "description": sentences_str,
             "type": self.event_type.value,
             "person": person_data
         }


### PR DESCRIPTION
Closes #60.

When adding a lead to Follow Up Boss, include the intent information (sentences), i.e. IAB categories, keywords, etc. that caused the lead to be flagged. 

Gives the FUB user insight into why that lead was given to them. 

Implemented in the vanilla deliverer, but with inheritance, is automatically implemented in the AI deliverer as AI deliverer calls `super()._prepare_event_data(...)`.

https://github.com/Standard-Labs/bigdbm-python/blob/c218d3722d972eedd9b1944fef7e36b9e3266bc6/bigdbm/deliver/followupboss/ai_fields.py#L197-L212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced event data processing by adding a "description" key that includes formatted intent information from a list of sentences.
  
- **Bug Fixes**
	- Improved the reliability of the output by ensuring relevant context is included in the processed event data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->