### PR TITLE
Warn if Follow Up Boss leads are on DNC

### DIFF
--- a/bigdbm/deliver/followupboss/ai_fields.py
+++ b/bigdbm/deliver/followupboss/ai_fields.py
@@ -90,27 +90,6 @@ class AIFollowUpBossDeliverer(FollowUpBossDeliverer):
 
         self.openai_client = openai.OpenAI(api_key=openai_api_key)
 
-    def _deliver(self, pii_md5s: list[MD5WithPII]) -> list[dict]:
-        """
-        Deliver the PII data to FollowUpBoss using AI field mapping.
-
-        This method attempts to deliver each lead individually using the AI-based method.
-        If the AI-based delivery fails for a lead, it falls back to the standard delivery method for that lead.
-
-        Args:
-            pii_md5s (list[MD5WithPII]): A list of MD5WithPII objects containing the PII data to be delivered.
-
-        Returns:
-            list[dict]: A list of response dictionaries from the FollowUpBoss API for each delivered event.
-        """
-        responses: list[dict] = []
-
-        for md5_with_pii in pii_md5s:
-            response = self._deliver_single_lead(md5_with_pii)
-            responses.append(response)
-
-        return responses
-
     def _deliver_single_lead(self, md5_with_pii: MD5WithPII) -> dict:
         """
         Deliver a single lead to FollowUpBoss, attempting AI-based delivery first and falling back to standard delivery if needed.


### PR DESCRIPTION
Fixes #61.

Log a warning if a Follow Up Boss deliverer is told to deliver at least 1 lead with a phone number on the DNC list. 

Applies to vanilla and AI deliverers. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new validation step to check leads against the Do Not Call (DNC) list, enhancing compliance measures.
  
- **Changes**
	- Removed the previous method for delivering PII data, simplifying the lead delivery process while maintaining individual lead delivery functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->