### PR TITLE
Add tags support to FollowUpBoss integration

### DIFF
--- a/bigdbm/deliver/followupboss/ai_fields.py
+++ b/bigdbm/deliver/followupboss/ai_fields.py
@@ -62,6 +62,7 @@ class AIFollowUpBossDeliverer(FollowUpBossDeliverer):
         system: str,
         system_key: str,
         openai_api_key: str,
+        tags: list[str] = [],
         base_url: str = "https://api.followupboss.com/v1",
         event_type: EventType = EventType.REGISTRATION,
         **kwargs
@@ -78,7 +79,15 @@ class AIFollowUpBossDeliverer(FollowUpBossDeliverer):
             event_type (EventType, optional): The event type for adding a lead. Defaults to Registration.
             **kwargs: Additional keyword arguments to be passed to the parent class.
         """
-        super().__init__(api_key, system, system_key, base_url, event_type, **kwargs)
+        super().__init__(
+            api_key=api_key,
+            system=system,
+            system_key=system_key,
+            tags=tags,
+            base_url=base_url,
+            event_type=event_type,
+            **kwargs
+        )
 
         try:
             import openai

--- a/bigdbm/deliver/followupboss/vanilla.py
+++ b/bigdbm/deliver/followupboss/vanilla.py
@@ -161,7 +161,7 @@ class FollowUpBossDeliverer(BaseOutputDeliverer):
         sentences_str = ", ".join(sentences)
         sentences_str = f"Intents: {sentences_str}."
 
-        # TEMP ADD TAGS
+        # Add tags to be applied to all leads
         person_data["tags"] = self.tags
 
         return {

--- a/bigdbm/deliver/followupboss/vanilla.py
+++ b/bigdbm/deliver/followupboss/vanilla.py
@@ -35,6 +35,7 @@ class FollowUpBossDeliverer(BaseOutputDeliverer):
             api_key: str, 
             system: str, 
             system_key: str, 
+            tags: list[str] = [],
             base_url: str = "https://api.followupboss.com/v1",
             event_type: EventType = EventType.REGISTRATION
         ):
@@ -51,6 +52,7 @@ class FollowUpBossDeliverer(BaseOutputDeliverer):
         self.api_key: str = api_key
         self.base_url: str = base_url
         self.system: str = system
+        self.tags: list[str] = tags
         self.system_key: str = system_key
 
         # Configuration stuff
@@ -158,6 +160,9 @@ class FollowUpBossDeliverer(BaseOutputDeliverer):
         
         sentences_str = ", ".join(sentences)
         sentences_str = f"Intents: {sentences_str}."
+
+        # TEMP ADD TAGS
+        person_data["tags"] = self.tags
 
         return {
             "source": self.system,


### PR DESCRIPTION
This PR adds support for tags in the FollowUpBoss integration. 

Changes:
- Added a 'tags' parameter to AIFollowUpBossDeliverer and FollowUpBossDeliverer classes
- Implemented passing of tags to the parent class in AIFollowUpBossDeliverer
- Added a 'self.tags' attribute to the FollowUpBossDeliverer class
- Incorporated tags into the person_data dictionary in FollowUpBossDeliverer

These changes allow for better categorization and organization of leads in FollowUpBoss.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new optional `tags` parameter for enhanced categorization during instance creation.
	- Tags are now included in the event data preparation, improving data management and lead tracking.

- **Bug Fixes**
	- Enhanced tests to verify the correct inclusion of tags in both prepared and delivered event data, ensuring functionality works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->